### PR TITLE
Fixed the phpdoc of the AbstractResult constructor

### DIFF
--- a/src/ZendDiagnostics/Result/AbstractResult.php
+++ b/src/ZendDiagnostics/Result/AbstractResult.php
@@ -22,8 +22,8 @@ abstract class AbstractResult implements ResultInterface
     /**
      * Create new result
      *
-     * @param null $message
-     * @param null $data
+     * @param string|null $message
+     * @param mixed|null  $data
      */
     public function __construct($message = null, $data = null)
     {


### PR DESCRIPTION
When analyzing LiipMonitorBundle with Scrutinizer, it reported a bunch of issues which are in fact related to the wrong type beign defined for these arguments
