### PR TITLE
Security Advisory: json_decode() expects parameter 1 to be string, array given

### DIFF
--- a/src/ZendDiagnostics/Check/SecurityAdvisory.php
+++ b/src/ZendDiagnostics/Check/SecurityAdvisory.php
@@ -75,9 +75,12 @@ class SecurityAdvisory extends AbstractCheck
             }
 
             $advisories = $this->securityChecker->check($this->lockFilePath, 'json');
-            $advisories = @json_decode($advisories);
 
-            if (null === $advisories) {
+            if (is_string($advisories)) {
+                $advisories = @json_decode($advisories);
+            }
+
+            if (!is_array($advisories)) {
                 return new Warning('Could not parse response from security advisory service.');
             }
 


### PR DESCRIPTION
**Problem:**
1. Run command `monitor:health`
2. Warning occurs: `WARNING Security Advisory: json_decode() expects parameter 1 to be string, array given`

**Solution:**
Remove `$advisories = @json_decode($advisories);` in `ZendDiagnostics\Check\SecurityAdvisory` and the warning is gone.
