### PR TITLE
Fix typos in DirWriteable check + add unit test based on vfsStream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "videlalvaro/php-amqplib"    : "2.*",
         "predis/predis"              : "0.8.*",
         "phpunit/phpunit"            : "4.7.*",
-        "doctrine/migrations"        : "~1.0@dev"
+        "doctrine/migrations"        : "~1.0@dev",
+        "mikey179/vfsStream"         : "1.6.*"
     },
     "suggest" : {
         "ext-bcmath" : "Required by Check\\CpuPerformance",

--- a/src/ZendDiagnostics/Check/DirWritable.php
+++ b/src/ZendDiagnostics/Check/DirWritable.php
@@ -28,7 +28,7 @@ class DirWritable extends AbstractCheck implements CheckInterface
     {
         if (is_object($path) && !$path instanceof Traversable) {
             throw new InvalidArgumentException(
-                'Expected a dir name (string) , an array or Traversable of strings, got ' . get_class($path)
+                'Expected a dir name (string), an array or Traversable of strings, got ' . get_class($path)
             );
         }
 
@@ -67,15 +67,15 @@ class DirWritable extends AbstractCheck implements CheckInterface
         // Construct failure message
         $failureString = '';
         if (count($nonDirs) > 1) {
-            $failureString .= 'The following paths are not valid directories: ' . join(', ', $nonDirs).' ';
+            $failureString .= sprintf('The following paths are not valid directories: %s. ', join(', ', $nonDirs));
         } elseif (count($nonDirs) == 1) {
-            $failureString .= current($nonDirs) . ' is not a valid directory. ';
+            $failureString .= sprintf('%s is not a valid directory. ', current($nonDirs));
         }
 
         if (count($unwritable) > 1) {
-            $failureString .= 'The following directories are not writable: ' . join(', ', $unwritable);
+            $failureString .= sprintf('The following directories are not writable: %s. ', join(', ', $unwritable));
         } elseif (count($unwritable) == 1) {
-            $failureString .= current($unwritable) . ' directory is not writable.';
+            $failureString .= sprintf('%s directory is not writable. ', current($unwritable));
         }
 
         // Return success or failure
@@ -83,7 +83,7 @@ class DirWritable extends AbstractCheck implements CheckInterface
             return new Failure(trim($failureString), array('nonDirs' => $nonDirs, 'unwritable' => $unwritable));
         } else {
             return new Success(
-                count($this->dir) > 1 ? 'All paths are writable directories.' : 'The path is a a writable directory.',
+                count($this->dir) > 1 ? 'All paths are writable directories.' : 'The path is a writable directory.',
                 $this->dir
             );
         }

--- a/tests/ZendDiagnosticsTest/ChecksTest.php
+++ b/tests/ZendDiagnosticsTest/ChecksTest.php
@@ -453,7 +453,7 @@ class ChecksTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $result);
         $this->assertStringMatchesFormat('%s' . $dir1 . '%s', $result->getMessage());
         $this->assertStringMatchesFormat('%s' . $dir2 . '%s', $result->getMessage());
-        $this->assertStringMatchesFormat('%simprobabledir999999999999', $result->getMessage());
+        $this->assertStringMatchesFormat('%simprobabledir999999999999%s', $result->getMessage());
 
         chmod($dir1, 0777);
         chmod($dir2, 0777);

--- a/tests/ZendDiagnosticsTest/ChecksTest.php
+++ b/tests/ZendDiagnosticsTest/ChecksTest.php
@@ -392,7 +392,7 @@ class ChecksTest extends \PHPUnit_Framework_TestCase
         $result = $check->check();
         $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $result, 'Non-dir path');
         $this->assertStringMatchesFormat('%s' . $path1 . '%s', $result->getMessage());
-        $this->assertStringMatchesFormat('%s' . $path2, $result->getMessage());
+        $this->assertStringMatchesFormat('%s' . $path2 . '%s', $result->getMessage());
 
         // create a barrage of unwritable directories
         $tmpDir = sys_get_temp_dir();

--- a/tests/ZendDiagnosticsTest/DirWritableTest.php
+++ b/tests/ZendDiagnosticsTest/DirWritableTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace ZendDiagnosticsTest;
+use org\bovigo\vfs\vfsStream;
+use ZendDiagnostics\Check\DirWritable;
+
+class DirWritableTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    private $checkClass = 'ZendDiagnostics\Check\DirWritable';
+
+    /**
+     * @test
+     */
+    public function shouldImplementCheckInterface()
+    {
+        $this->assertInstanceOf(
+            'ZendDiagnostics\Check\CheckInterface',
+            $this->prophesize($this->checkClass)->reveal()
+        );
+    }
+
+    /**
+     * @dataProvider providerValidConstructorArguments
+     */
+    public function testConstructor($arguments)
+    {
+        $object = new DirWritable($arguments);
+    }
+
+    public function providerValidConstructorArguments()
+    {
+        return array(
+            array(__DIR__),
+            array(vfsStream::setup()->url()),
+            array(array(__DIR__, vfsStream::setup()->url()))
+        );
+    }
+
+    public function testCheckSuccessSinglePath()
+    {
+        $object = new DirWritable(vfsStream::setup()->url());
+        $r = $object->check();
+        $this->assertInstanceOf('ZendDiagnostics\Result\Success', $r);
+        $this->assertEquals('The path is a writable directory.', $r->getMessage());
+    }
+
+    public function testCheckSuccessMultiplePaths()
+    {
+        $object = new DirWritable(array(__DIR__, vfsStream::setup()->url()));
+        $r = $object->check();
+        $this->assertInstanceOf('ZendDiagnostics\Result\Success', $r);
+        $this->assertEquals('All paths are writable directories.', $r->getMessage());
+    }
+
+    public function testCheckFailureSingleInvalidDir()
+    {
+        $object = new DirWritable('notadir');
+        $r = $object->check();
+        $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $r);
+        $this->assertContains('notadir is not a valid directory.', $r->getMessage());
+    }
+
+    public function testCheckFailureMultipleInvalidDirs()
+    {
+        $object = new DirWritable(array('notadir1', 'notadir2'));
+        $r = $object->check();
+        $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $r);
+        $this->assertContains('The following paths are not valid directories: notadir1, notadir2.', $r->getMessage());
+    }
+
+    public function testCheckFailureSingleUnwritableDir()
+    {
+        $root = vfsStream::setup();
+        $unwritableDir = vfsStream::newDirectory('unwritabledir', 000)->at($root);
+        $object = new DirWritable($unwritableDir->url());
+        $r = $object->check();
+        $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $r);
+        $this->assertEquals('vfs://root/unwritabledir directory is not writable.', $r->getMessage());
+    }
+
+    public function testCheckFailureMultipleUnwritableDirs()
+    {
+        $root = vfsStream::setup();
+        $unwritableDir1 = vfsStream::newDirectory('unwritabledir1', 000)->at($root);
+        $unwritableDir2 = vfsStream::newDirectory('unwritabledir2', 000)->at($root);
+
+        $object = new DirWritable(array($unwritableDir1->url(), $unwritableDir2->url()));
+        $r = $object->check();
+        $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $r);
+        $this->assertEquals('The following directories are not writable: vfs://root/unwritabledir1, vfs://root/unwritabledir2.', $r->getMessage());
+    }
+
+}

--- a/tests/ZendDiagnosticsTest/DirWritableTest.php
+++ b/tests/ZendDiagnosticsTest/DirWritableTest.php
@@ -1,6 +1,6 @@
 <?php
-
 namespace ZendDiagnosticsTest;
+
 use org\bovigo\vfs\vfsStream;
 use ZendDiagnostics\Check\DirWritable;
 
@@ -92,5 +92,4 @@ class DirWritableTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendDiagnostics\Result\Failure', $r);
         $this->assertEquals('The following directories are not writable: vfs://root/unwritabledir1, vfs://root/unwritabledir2.', $r->getMessage());
     }
-
 }


### PR DESCRIPTION
Hi!

First of all i want to say "thank you" for these components! We use them in production together with the Liip Monitor bundle and its very very helpful. So: Thanks for your work!

I recently spotted a small typo in the "DirWritable" check. There was an doubled "a" in the message "The path is a writable directory." Additionally i added some missing dots. :)

I tried to fix it with the existing unit-tests but unfortunately they do not work for me mainly because i'm on a Windows system (chmod stuff simply doesnt work on win machines). So i decided to add a new testsuite especially for the DirWriteable check implementing checks using a virtual filesystem based on vfsStream.

Actually i dont know if this pr breaks some of the existing tests. There is no need to add my tests when you fix the typo by yourself. :)

Thanks again.

Regards

Kai