### PR TITLE
Trying to get rid of risky tests

### DIFF
--- a/tests/ZendDiagnosticsTest/BasicConsoleReporterTest.php
+++ b/tests/ZendDiagnosticsTest/BasicConsoleReporterTest.php
@@ -86,7 +86,6 @@ class BasicConsoleReporterTest extends \PHPUnit_Framework_TestCase
         $this->reporter->onStart($checks, array());
         ob_clean();
 
-        ob_start();
         foreach ($checks as $alias => $check) {
             $result = new Unknown();
             $this->reporter->onAfterRun($check, $result, $alias);
@@ -104,7 +103,6 @@ class BasicConsoleReporterTest extends \PHPUnit_Framework_TestCase
         $this->reporter->onStart($checks, array());
         ob_clean();
 
-        ob_start();
         foreach ($checks as $alias => $check) {
             $result = new Success();
             $this->reporter->onAfterRun($check, $result, $alias);
@@ -122,7 +120,6 @@ class BasicConsoleReporterTest extends \PHPUnit_Framework_TestCase
         $this->reporter->onStart($checks, array());
         ob_clean();
 
-        ob_start();
         foreach ($checks as $alias => $check) {
             $result = new Success();
             $this->reporter->onAfterRun($check, $result, $alias);
@@ -145,7 +142,6 @@ class BasicConsoleReporterTest extends \PHPUnit_Framework_TestCase
         $this->reporter->onStart($checks, array());
         ob_clean();
 
-        ob_start();
         foreach ($checks as $alias => $check) {
             $result = new Success();
             $this->reporter->onAfterRun($check, $result, $alias);


### PR DESCRIPTION
Referencing #50.

As `ob_clean()` does not close the buffer, there is no need for another `ob_start()`.