### PR TITLE
Fix typo in HttpService PHPDoc

### DIFF
--- a/src/ZendDiagnostics/Check/HttpService.php
+++ b/src/ZendDiagnostics/Check/HttpService.php
@@ -43,7 +43,7 @@ class HttpService extends AbstractCheck
      * @param int    $port       Port to connect to (defaults to 80)
      * @param string $path       The path to retrieve (defaults to /)
      * @param int    $statusCode (optional) Expected status code
-     * @param null   $content    (optional) Expected substring to match agains the page content.
+     * @param null   $content    (optional) Expected substring to match against the page content.
      */
     public function __construct($host, $port = 80, $path = '/', $statusCode = null, $content = null)
     {


### PR DESCRIPTION
Add the missing 't' to the `$content` parameter description text.