### PR TITLE
adds dsn to PDO-Check label

### DIFF
--- a/src/ZendDiagnostics/Check/PDOCheck.php
+++ b/src/ZendDiagnostics/Check/PDOCheck.php
@@ -66,6 +66,6 @@ class PDOCheck implements CheckInterface
      */
     public function getLabel()
     {
-        return 'Check if the database server can be reached';
+        return sprintf('Check if %s can be reached', $this->dsn);
     }
 }


### PR DESCRIPTION
This is a proposal, my usecase is, if i have multiple PDO-Connections to be Checked, i do not know which one is not working, the dsn can give me at least some information about which connection is not working.