### PR TITLE
Correcting syntax in code examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Install the [rstgroup/diagnostics-middleware](https://github.com/rstgroup/diagno
 For example:
 
 ````php
+<?php
 // run_diagnostics.php
 
 use ZendDiagnostics\Check;
@@ -84,7 +85,7 @@ $runner = new Runner();
 
 // Add checks
 $runner->addCheck(new Check\DirWritable('/tmp'));
-$runner->addCheck(new Check\DiskFree('/tmp', 100000000));
+$runner->addCheck(new Check\DiskFree(100000000, '/tmp'));
 
 // Add console reporter
 $runner->addReporter(new BasicConsole(80, true));
@@ -114,8 +115,9 @@ attached Reporter). This collection contains results for all tests and failure c
 Simple example:
 
 ````php
+<?php
 $runner = new Runner();
-$checkSpace = new Check\DiskFree('/tmp', 100000000);
+$checkSpace = new Check\DiskFree(100000000, '/tmp');
 $checkTemp  = new Check\DirWritable('/tmp');
 $runner->addCheck($checkSpace);
 $runner->addCheck($checkTemp);
@@ -167,6 +169,7 @@ applications and libraries.
 A Check class has to implement [Check](src/ZendDiagnostics/Check/CheckInterface.php) and provide the following methods:
 
 ````php
+<?php
 interface CheckInterface
 {
     /**
@@ -190,6 +193,7 @@ compatibility with Runner and other checks.
 Here is an example trivial class, that will check if PHP default timezone is set to UTC.
 
 ````php
+<?php
 namespace MyApp\Diagnostics\Check;
 
 use ZendDiagnostics\Check\CheckInterface;
@@ -221,6 +225,7 @@ class TimezoneSetToUTC implements CheckInterface
 A Reporter is a class implementing [ReporterInterface](src/ZendDiagnostics/Runner/Reporter/ReporterInterface.php).
 
 ````php
+<?php
 interface ReporterInterface
 {
     public function onStart(ArrayObject $checks, $runnerConfig);


### PR DESCRIPTION
DiskFree usage was reversed in a couple examples. Also, added `<?php` to match other examples.