### PR TITLE
fix PHP 7.2 issue and update the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,21 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
-  - 5.3.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_install:
   - composer self-update
   - phpenv config-rm xdebug.ini
-  - if [[ "$TRAVIS_PHP_VERSION" != "5.3" && "$TRAVIS_PHP_VERSION" != "5.3.3" ]]; then composer require --no-update guzzlehttp/guzzle:~4; fi
-  - if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then composer require --no-update fabpot/php-cs-fixer:1.9.*; fi
+  - composer require --no-update fabpot/php-cs-fixer:1.9.*
 
 install: composer update $COMPOSER_FLAGS --prefer-dist
 
 script:
   - ./vendor/bin/phpunit -c ./tests/ --coverage-text
-  - if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then ./vendor/bin/php-cs-fixer fix -v --dry-run --level=psr2 .; fi
+  - ./vendor/bin/php-cs-fixer fix -v --dry-run --level=psr2 .
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         }
     },
     "require": {
-        "php": ">=5.3.3"
+        "php": "^5.6|^7.0"
     },
     "require-dev": {
-        "zendframework/zend-loader"  : "2.*",
-        "sensiolabs/security-checker": "1.3.*@dev",
-        "symfony/yaml"               : "v2.3.11",
-        "guzzle/http"                : "3.*",
-        "guzzle/plugin-mock"         : "3.*",
-        "videlalvaro/php-amqplib"    : "2.*",
-        "predis/predis"              : "0.8.*",
-        "phpunit/phpunit"            : "4.7.*",
-        "doctrine/migrations"        : "~1.0@dev",
-        "mikey179/vfsStream"         : "1.6.*"
+        "zendframework/zend-loader"  : "^2.0",
+        "sensiolabs/security-checker": "^1.3",
+        "symfony/yaml"               : "^2.7|^3.0|^4.0",
+        "guzzle/http"                : "^3.0",
+        "guzzle/plugin-mock"         : "^3.0",
+        "php-amqplib/php-amqplib"    : "^2.0",
+        "predis/predis"              : "^1.0",
+        "phpunit/phpunit"            : "^4.7|^5.0",
+        "doctrine/migrations"        : "^1.0",
+        "mikey179/vfsStream"         : "^1.6"
     },
     "suggest" : {
         "ext-bcmath" : "Required by Check\\CpuPerformance",

--- a/src/ZendDiagnostics/Result/Collection.php
+++ b/src/ZendDiagnostics/Result/Collection.php
@@ -127,7 +127,7 @@ class Collection extends \SplObjectStorage
      * @param mixed|null $checkResult
      * @link http://php.net/manual/en/splobjectstorage.offsetset.php
      */
-    public function offsetSet($index, $checkResult)
+    public function offsetSet($index, $checkResult = null)
     {
         $this->validateIndex($index);
         $this->validateValue($checkResult);


### PR DESCRIPTION
minor PHP 7.2 fix .. also updated the build matrix for PHP versions that are not EOL.
not sure if ZendFramework supports even older versions ..

I also updated the dependencies to stable versions. However there might be some new major versions that should also be allowed.

Once this is merged I guess we will tag 1.1.0?